### PR TITLE
Changing download service to base64

### DIFF
--- a/amorphie.contract.application/Customer/CustomerAppService.cs
+++ b/amorphie.contract.application/Customer/CustomerAppService.cs
@@ -260,7 +260,7 @@ namespace amorphie.contract.application.Customer
                 var documentDefinition = documents.FirstOrDefault(z => z.DocumentDefinitionId == minioDoc.DocumentDefinitionId);
                 if (documentDefinition != null)
                 {
-                    string minioUrl = $"{_baseUrl}{_downloadEndpoint}?ObjectName={documentDefinition.DocumentContentId}";
+                    string minioUrl = $"{_baseUrl}{_downloadEndpoint}?ObjectId={documentDefinition.DocumentContentId}";
 
                     minioDoc.MinioUrl = minioUrl;
                 }

--- a/amorphie.contract.application/Document/Dto/DocumentDownloadInputDto.cs
+++ b/amorphie.contract.application/Document/Dto/DocumentDownloadInputDto.cs
@@ -5,7 +5,7 @@ namespace amorphie.contract.application;
 public class DocumentDownloadInputDto
 {
     [Required]
-    public required string ObjectName { get; set; }
+    public required string ObjectId { get; set; }
 
     private string _userReference;
 

--- a/amorphie.contract.application/Document/Dto/DocumentDownloadOutputDto.cs
+++ b/amorphie.contract.application/Document/Dto/DocumentDownloadOutputDto.cs
@@ -1,0 +1,10 @@
+namespace amorphie.contract.application;
+
+public class DocumentDownloadOutputDto
+{
+    public string FileName { get; init; } = null!;
+
+    public string FileType { get; init; } = null!;
+
+    public string FileContent { get; set; } = null!;
+}

--- a/amorphie.contract.core/Model/Minio/GetMinioObjectModel.cs
+++ b/amorphie.contract.core/Model/Minio/GetMinioObjectModel.cs
@@ -1,0 +1,11 @@
+namespace amorphie.contract.core.Model.Minio;
+
+public class GetMinioObjectModel
+{
+    public string FileName { get; init; } = null!;
+
+    public string ContentType { get; init; } = null!;
+
+    public string FileContent { get; set; } = null!;
+
+}

--- a/amorphie.contract.core/Services/IMinioService.cs
+++ b/amorphie.contract.core/Services/IMinioService.cs
@@ -1,3 +1,5 @@
+using amorphie.contract.core.Model.Minio;
+
 namespace amorphie.contract.core.Services
 {
     public interface IMinioService
@@ -9,7 +11,6 @@ namespace amorphie.contract.core.Services
         //TODO: Daha sonra tek bir interface altında toplanacak. (Zeebe)
         Task UploadFile(byte[] data, string objectName, string contentType);
 
-        Task<ReleaseableFileStreamModel> DownloadFile(string objectName, CancellationToken cancellationToken);
-
+        Task<GetMinioObjectModel> DownloadFile(string objectName, CancellationToken cancellationToken);
     }
 }

--- a/amorphie.contract.infrastructure/Middleware/ApiExceptionHandleMiddleware.cs
+++ b/amorphie.contract.infrastructure/Middleware/ApiExceptionHandleMiddleware.cs
@@ -40,6 +40,13 @@ namespace amorphie.contract.infrastructure.Middleware
             //TODO: COmment ds
             switch (ex)
             {
+                case FileNotFoundException fileNotFoundException:
+                    {
+                        statusCode = (int)HttpStatusCode.NotFound;
+                        title = "fileNotFoundException Error";
+                        messages.Add(fileNotFoundException.Message);
+                        break;
+                    }
                 case InvalidOperationException validationExp:
                     {
                         statusCode = (int)HttpStatusCode.BadRequest;

--- a/amorphie.contract/Module/Document/DocumentModule.cs
+++ b/amorphie.contract/Module/Document/DocumentModule.cs
@@ -10,6 +10,7 @@ using amorphie.contract.core.Services;
 using amorphie.contract.Extensions;
 using amorphie.contract.core.Model.Colleteral;
 using amorphie.contract.core.Response;
+using amorphie.core.Base;
 
 namespace amorphie.contract;
 
@@ -78,14 +79,14 @@ public class DocumentModule
         });
     }
 
-    async ValueTask DownloadDocument([FromServices] IDocumentAppService documentAppService, HttpContext httpContext, [AsParameters] DocumentDownloadInputDto inputDto, CancellationToken token)
+    async Task<GenericResult<DocumentDownloadOutputDto>> DownloadDocument([FromServices] IDocumentAppService documentAppService, HttpContext httpContext, [AsParameters] DocumentDownloadInputDto inputDto, CancellationToken token)
     {
         var headerModels = HeaderHelper.GetHeader(httpContext);
         inputDto.SetUserReference(headerModels.UserReference);
 
-        var doc = await documentAppService.DownloadDocument(inputDto, token);
-        httpContext.Response.ContentType = doc.Data.ContentType;
-        await doc.Data.Stream.CopyToAsync(httpContext.Response.Body);
+        var resDocument = await documentAppService.DownloadDocument(inputDto, token);
+
+        return resDocument;
     }
 
     [Topic(KafkaConsts.KafkaName, KafkaConsts.SendDocumentInstanceDataToDYSTopicName)]

--- a/dapr/components/amorphie-secretstore.yaml
+++ b/dapr/components/amorphie-secretstore.yaml
@@ -1,7 +1,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: amorphie-secretstore
+  name: contract-secretstore
 spec:
   type: secretstores.hashicorp.vault
   version: v1
@@ -15,4 +15,4 @@ spec:
     - name: vaultKVUsePrefix
       value: false
     - name: enginePath
-      value: "amorphie-workflow"
+      value: "secret"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new data transfer object `DocumentDownloadOutputDto` for returning document file details.
	- Added a new model `GetMinioObjectModel` to represent Minio object information.
- **Bug Fixes**
	- Updated the `ApiExceptionHandleMiddleware` to handle `FileNotFoundException`, improving error reporting.
- **Refactor**
	- Updated query parameter name from `ObjectName` to `ObjectId` across various services to enhance consistency.
	- Changed the return type of the `DownloadDocument` method to improve data encapsulation and type safety.
	- Refactored the file download logic in `MinioService` to use a `MemoryStream` and base64 encoding, optimizing file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->